### PR TITLE
docs: Update baby announcement page with July progress and nursery details

### DIFF
--- a/fern/docs/pages/baby.mdx
+++ b/fern/docs/pages/baby.mdx
@@ -10,7 +10,7 @@ hide-toc: true
 <div>
   <img 
     alt="Ultrasound showing baby waving" 
-    src="./ultra.png" 
+    src="file:47397423-7d85-48cf-b400-0b905bda39ac" 
     width="300" 
     style={{
       borderRadius: '12px',
@@ -21,12 +21,29 @@ hide-toc: true
 </div>
 
 ## What's next?
+
 Get ready for a new little Sheridan to join our crew in August 2025! 
 
 Here's what we know so far:
-- 📅 Due Date: August 2025
-- 👶 Gender: It's going to be a surprise!
-- 🗽 Location: New York City
-- 🏡 Fun Fact: Our little one will grow up right across from a playground (perfect for visits from their cousins!)
+
+
+
+* 📅 Due Date: August 2025
+
+* 👶 Gender: It's going to be a surprise!
+
+* 🗽 Location: New York City
+
+* 🏡 Fun Fact: Our little one will grow up right across from a playground (perfect for visits from their cousins!)
 
 **Hugs & cuddles inbound!**
+
+**Update as of 7/16**
+
+* Baby Sheridan is growing bigger every week.
+
+* We have the nursery complete and gender neutral decor.
+
+* We plan to publish a picture or two after the birth to this site, so stay tuned.
+
+* If you want to support us after birth, please refer to the how to TK page.


### PR DESCRIPTION

Updates the baby announcement page with new information as of July 16th, including details about the nursery preparation, growth updates, and plans for future photos. The changes also include reformatting the bullet points for better readability and updating the ultrasound image source. The update provides more context for family and friends about the baby's progress and sets expectations for post-birth updates and support.     
<br>
    
🌿 _This PR title and description were generated by Fern._
    [(buildwithfern.com)](https://www.buildwithfern.com)